### PR TITLE
fixed errors thrown when x axis is a subset of the data being plotted

### DIFF
--- a/R/position-beeswarm.R
+++ b/R/position-beeswarm.R
@@ -33,6 +33,7 @@ PositionBeeswarm <- proto::proto(ggplot2:::Position, {
 
 	# Adjust function is used to calculate new positions (from ggplot2:::Position)
 	adjust <- function(., data) {
+		data <- data[complete.cases(data),]
 		if (empty(data)) return(data.frame())
 		check_required_aesthetics(c("x", "y"), names(data), "position_beeswarm")
 

--- a/R/position-quasirandom.R
+++ b/R/position-quasirandom.R
@@ -35,6 +35,7 @@ PositionQuasirandom <- proto::proto(ggplot2:::Position, {
 
   # Adjust function is used to calculate new positions (from ggplot2:::Position)
   adjust <- function(., data) {
+	 data <- data[complete.cases(data),]
 	 if (empty(data)) return(data.frame())
 	 check_required_aesthetics(c("x", "y"), names(data), "position_quasirandom")
 	


### PR DESCRIPTION
When using `xlim` or `scale_x_continuous(limits )`, errors are thrown, e.g.:

```{R} 
position_quasirandom(varwidth=TRUE)) +     scale_x_continuous(limits=c(-7,7))
```
>Error in density.default(y, n = nbins, adjust = adjust) : 
  'x' contains missing values

Suggested a fix for this.