### PR TITLE
Added `dodge.width` option

### DIFF
--- a/R/geom-beeswarm.R
+++ b/R/geom-beeswarm.R
@@ -29,7 +29,7 @@
 #'     geom_beeswarm(priority='density',cex=2.5)
 geom_beeswarm <- function(mapping = NULL, data = NULL,
   priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,dodge.width=0,
-  stat='identity',position = "dodge", na.rm = FALSE,
+  stat='identity',position = "quasirandom", na.rm = FALSE,
   show.legend = NA, inherit.aes = TRUE, ...) {
   position <- position_beeswarm(priority = priority, cex = cex, groupOnX=groupOnX,dodge.width=0)
 

--- a/R/geom-beeswarm.R
+++ b/R/geom-beeswarm.R
@@ -31,7 +31,7 @@ geom_beeswarm <- function(mapping = NULL, data = NULL,
   priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,dodge.width=0,
   stat='identity',position = "quasirandom", na.rm = FALSE,
   show.legend = NA, inherit.aes = TRUE, ...) {
-  position <- position_beeswarm(priority = priority, cex = cex, groupOnX=groupOnX,dodge.width=0)
+  position <- position_beeswarm(priority = priority, cex = cex, groupOnX=groupOnX,dodge.width=dodge.width)
 
   ggplot2::layer(
     data = data,

--- a/R/geom-beeswarm.R
+++ b/R/geom-beeswarm.R
@@ -29,7 +29,7 @@
 #'     geom_beeswarm(priority='density',cex=2.5)
 geom_beeswarm <- function(mapping = NULL, data = NULL,
   priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,
-  stat='identity',position = "quasirandom", na.rm = FALSE,
+  stat='identity',position = "dodge", na.rm = FALSE,
   show.legend = NA, inherit.aes = TRUE, ...) {
   position <- position_beeswarm(priority = priority, cex = cex, groupOnX=groupOnX)
 

--- a/R/geom-beeswarm.R
+++ b/R/geom-beeswarm.R
@@ -28,10 +28,10 @@
 #'   ggplot2::qplot(variable, value, data = distro) +
 #'     geom_beeswarm(priority='density',cex=2.5)
 geom_beeswarm <- function(mapping = NULL, data = NULL,
-  priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,
+  priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,dodge.width=0,
   stat='identity',position = "dodge", na.rm = FALSE,
   show.legend = NA, inherit.aes = TRUE, ...) {
-  position <- position_beeswarm(priority = priority, cex = cex, groupOnX=groupOnX)
+  position <- position_beeswarm(priority = priority, cex = cex, groupOnX=groupOnX,dodge.width=0)
 
   ggplot2::layer(
     data = data,

--- a/R/geom-quasirandom.R
+++ b/R/geom-quasirandom.R
@@ -26,7 +26,7 @@
 #' @export
 geom_quasirandom <- function(mapping = NULL, data = NULL,
   width = NULL, varwidth = FALSE, bandwidth=.5,nbins=1000,method='quasirandom',groupOnX=NULL,dodge.width=0,
-  stat='identity',position = "dodge", na.rm = FALSE,
+  stat='identity',position = "quasirandom", na.rm = FALSE,
   show.legend = NA, inherit.aes = TRUE, ...) {
   position <- position_quasirandom(width = width, varwidth = varwidth, bandwidth=bandwidth,nbins=nbins,method=method,groupOnX=groupOnX,dodge.width=dodge.width)
 

--- a/R/geom-quasirandom.R
+++ b/R/geom-quasirandom.R
@@ -25,10 +25,10 @@
 #'   ggplot2::qplot(variable, value, data = distro) + geom_quasirandom(width=0.1)
 #' @export
 geom_quasirandom <- function(mapping = NULL, data = NULL,
-  width = NULL, varwidth = FALSE, bandwidth=.5,nbins=1000,method='quasirandom',groupOnX=NULL,
-  stat='identity',position = "quasirandom", na.rm = FALSE,
+  width = NULL, varwidth = FALSE, bandwidth=.5,nbins=1000,method='quasirandom',groupOnX=NULL,dodge.width=0,
+  stat='identity',position = "dodge", na.rm = FALSE,
   show.legend = NA, inherit.aes = TRUE, ...) {
-  position <- position_quasirandom(width = width, varwidth = varwidth, bandwidth=bandwidth,nbins=nbins,method=method,groupOnX=groupOnX)
+  position <- position_quasirandom(width = width, varwidth = varwidth, bandwidth=bandwidth,nbins=nbins,method=method,groupOnX=groupOnX,dodge.width=dodge.width)
 
   ggplot2::layer(
     data = data,

--- a/R/position-beeswarm.R
+++ b/R/position-beeswarm.R
@@ -20,12 +20,15 @@
 #'     geom_beeswarm(priority='density',cex=2.5)
 #'
 position_beeswarm <- function (priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,dodge.width=0.5) {
-  ggplot2::ggproto(NULL,PositionBeeswarm,priority = priority,cex=cex,groupOnX=NULL)
+  ggplot2::ggproto(NULL,PositionBeeswarm,priority = priority,cex=cex,groupOnX=NULL,dodge.width=dodge.width)
 }
 
 PositionBeeswarm <- ggplot2::ggproto("PositionBeeswarm",ggplot2:::Position, required_aes=c('x','y'),
   setup_params=function(self,data){
-    list(priority=self$priority,cex=self$cex,groupOnX=self$groupOnX)
+    list(priority=self$priority,
+    cex=self$cex,
+    groupOnX=self$groupOnX,
+    dodge.width=self$dodge.width)
   },
   compute_panel=function(data,params,scales){
 	# Adjust function is used to calculate new positions (from ggplot2:::Position)

--- a/R/position-beeswarm.R
+++ b/R/position-beeswarm.R
@@ -19,7 +19,7 @@
 #'   ggplot2::qplot(variable, value, data = distro) +
 #'     geom_beeswarm(priority='density',cex=2.5)
 #'
-position_beeswarm <- function (priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,dodge.width=0.5) {
+position_beeswarm <- function (priority = c("ascending", "descending", "density", "random", "none"),cex=2,groupOnX=NULL,dodge.width=0) {
   ggplot2::ggproto(NULL,PositionBeeswarm,priority = priority,cex=cex,groupOnX=NULL,dodge.width=dodge.width)
 }
 

--- a/R/position-beeswarm.R
+++ b/R/position-beeswarm.R
@@ -4,6 +4,7 @@
 #' @param priority Method used to perform point layout (see \code{\link{swarmx}})
 #' @param cex Scaling for adjusting point spacing (see \code{\link{swarmx}})
 #' @param groupOnX should jitter be added to the x axis if TRUE or y axis if FALSE (the default NULL causes the function to guess which axis is the categorical one based on the number of unique entries in each)
+#' @param dodge.width Amount by which points from different aesthetic groups will be dodged. This requires that one of the aesthetics is a factor.
 #' @export
 #' @importFrom beeswarm swarmx
 #' @seealso \code{\link{position_quasirandom}}, \code{\link[beeswarm]{swarmx}} 

--- a/R/position-quasirandom.R
+++ b/R/position-quasirandom.R
@@ -8,6 +8,7 @@
 #' @param nbins the number of bins used when calculating density (has little effect with quasirandom/random distribution)
 #' @param method the method used for distributing points (quasirandom, pseudorandom, smiley or frowney)
 #' @param groupOnX should jitter be added to the x axis if TRUE or y axis if FALSE (the default NULL causes the function to guess which axis is the categorical one based on the number of unique entries in each)
+#' @param dodge.width Amount by which points from different aesthetic groups will be dodged. This requires that one of the aesthetics is a factor.
 #' @export
 #' @importFrom vipor offsetX
 #' @seealso \code{\link[vipor]{offsetX}}

--- a/R/position-quasirandom.R
+++ b/R/position-quasirandom.R
@@ -22,18 +22,26 @@
 #'   ggplot2::qplot(variable, value, data = distro, geom = 'quasirandom')
 #'   ggplot2::qplot(variable, value, data = distro) + geom_quasirandom(width=0.1)
 #'
-position_quasirandom <- function (width = NULL, varwidth = FALSE, bandwidth=.5,nbins=1000,method='quasirandom',groupOnX=NULL) {
-  ggplot2::ggproto(NULL,PositionQuasirandom,width = width, varwidth = varwidth, bandwidth=bandwidth,nbins=nbins,method=method,groupOnX=groupOnX)
+position_quasirandom <- function (width = NULL, varwidth = FALSE, bandwidth=.5,nbins=1000,method='quasirandom',groupOnX=NULL,dodge.width=0) {
+  ggplot2::ggproto(NULL,PositionQuasirandom,width = width, varwidth = varwidth, bandwidth=bandwidth,nbins=nbins,method=method,groupOnX=groupOnX,dodge.width=dodge.width)
 }
 
 PositionQuasirandom <- ggplot2::ggproto("PositionQuasirandom",ggplot2:::Position,required_aes=c('x','y'),
   setup_params=function(self,data){
-    list(width=self$width,varwidth=self$varwidth,bandwidth=self$bandwidth,nbins=self$nbins,method=self$method,groupOnX=self$groupOnX)
+    list(width=self$width,varwidth=self$varwidth,bandwidth=self$bandwidth,nbins=self$nbins,method=self$method,groupOnX=self$groupOnX,dodge.width=self$dodge.width)
   },
   compute_layer= function(data,params,panel) {
     data <- remove_missing(data, vars = c("x","y"), name = "position_quasirandom")
     if (nrow(data)==0) return(data.frame())
-
+    
+  # dodge
+    data <- ggplot2:::collide(data,
+    params$dodge.width,
+    "position_dodge", 
+    ggplot2:::pos_dodge,
+    check.width = FALSE)
+  
+  # then quasirandom transform
     trans_x <- NULL
     trans_y <- NULL
     


### PR DESCRIPTION
Both `geom_beeswarm` and `geom_quasirandom` will now dodge, if __both__ the following conditions are met:

* one of the aesthetics is a factor, and 
* the argument `dodge.width` is explicitly given in the function call.