### PR TITLE
added source & issue URLs to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,8 @@ Authors@R: c(
 Description: Provides two methods of plotting categorical scatter plots such
     that the arrangement of points within a category reflects the density of
     data at that region, and avoids over-plotting.
+URL: https://github.com/eclarke/ggbeeswarm
+BugReports: https://github.com/eclarke/ggbeeswarm/issues
 License: GPL (>=2)
 Depends:
     R (>= 3.0.0),


### PR DESCRIPTION
leaving them out may have been a deliberate choice. apologies for the disruption if that is the case :-)

generally, though, quick access to the gh URLs from DESCRIPTION makes it easier for folks to find/contribute/etc. Sadly, it's not well-documented in the R pkgs docs.