### PR TITLE
Fix qplot examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggbeeswarm
 Type: Package
 Title: Categorical Scatter (Violin Point) Plots
 Version: 0.5.3
-Date: 2016-12-01
+Date: 2016-12-10
 Authors@R: c(
     person(given="Erik", family="Clarke", role=c("aut", "cre"), email="erikclarke@gmail.com"),
     person(given="Scott", family="Sherrill-Mix", role=c("aut"), email="sherrillmix@gmail.com"))

--- a/R/geom-beeswarm.R
+++ b/R/geom-beeswarm.R
@@ -25,7 +25,7 @@
 #'     'value'=c(runif(100, min=-3, max=3), rnorm(100))
 #'   )
 #'   ggplot2::qplot(variable, value, data = distro, geom='beeswarm')
-#'   ggplot2::qplot(variable, value, data = distro) +
+#'   ggplot2::ggplot(distro,aes(variable, value)) +
 #'     geom_beeswarm(priority='density',cex=2.5)
 geom_beeswarm <- function(
   mapping = NULL,

--- a/R/geom-quasirandom.R
+++ b/R/geom-quasirandom.R
@@ -22,7 +22,7 @@
 #'     'value'=c(runif(100, min=-3, max=3), rnorm(100))
 #'   )
 #'   ggplot2::qplot(variable, value, data = distro, geom = 'quasirandom')
-#'   ggplot2::qplot(variable, value, data = distro) + geom_quasirandom(width=0.1)
+#'   ggplot2::ggplot(distro,aes(variable, value)) + geom_quasirandom(width=0.1)
 #' @export
 geom_quasirandom <- function(
   mapping = NULL,

--- a/R/ggbeeswarm-package.R
+++ b/R/ggbeeswarm-package.R
@@ -7,7 +7,7 @@
 #' @seealso \code{\link{position_quasirandom}}
 #' @examples
 #' 
-#'   ggplot2::qplot(class, hwy, data = ggplot2::mpg, position=position_quasirandom())
+#'   ggplot2::ggplot(ggplot2::mpg,aes(class, hwy)) + geom_quasirandom()
 #'   # Generate fake data
 #'   distro <- data.frame(
 #'     'variable'=rep(c('runif','rnorm'),each=100),

--- a/R/ggbeeswarm-package.R
+++ b/R/ggbeeswarm-package.R
@@ -13,8 +13,8 @@
 #'     'variable'=rep(c('runif','rnorm'),each=100),
 #'     'value'=c(runif(100, min=-3, max=3), rnorm(100))
 #'   )
-#'   ggplot2::qplot(variable, value, data = distro, position = position_quasirandom())
-#'   ggplot2::qplot(variable, value, data = distro, position = position_quasirandom(width=0.1))
+#'   ggplot2::ggplot(distro,aes(variable, value)) + geom_quasirandom()
+#'   ggplot2::ggplot(distro,aes(variable, value)) + geom_quasirandom(width=.1)
 #' 
 NULL
 

--- a/R/position-beeswarm.R
+++ b/R/position-beeswarm.R
@@ -10,15 +10,7 @@
 #' @seealso \code{\link{position_quasirandom}}, \code{\link[beeswarm]{swarmx}} 
 #' @examples
 #' 
-#'   ggplot2::qplot(class, hwy, data = ggplot2::mpg, geom='beeswarm')
-#'   # Generate fake data
-#'   distro <- data.frame(
-#'     'variable'=rep(c('runif','rnorm'),each=100),
-#'     'value'=c(runif(100, min=-3, max=3), rnorm(100))
-#'   )
-#'   ggplot2::qplot(variable, value, data = distro, geom='beeswarm')
-#'   ggplot2::qplot(variable, value, data = distro) +
-#'     geom_beeswarm(priority='density',cex=2.5)
+#'   ggplot2::qplot(class, hwy, data = ggplot2::mpg, position=position_beeswarm())
 #'
 position_beeswarm <- function (priority = c("ascending", "descending", "density", "random", "none"),cex=1,groupOnX=NULL,dodge.width=0){
   ggplot2::ggproto(NULL,PositionBeeswarm,priority = priority,cex=cex,groupOnX=NULL,dodge.width=dodge.width)

--- a/R/position-quasirandom.R
+++ b/R/position-quasirandom.R
@@ -14,14 +14,7 @@
 #' @seealso \code{\link[vipor]{offsetX}}
 #' @examples
 #' 
-#'   ggplot2::qplot(class, hwy, data = ggplot2::mpg, geom='quasirandom')
-#'   # Generate fake data
-#'   distro <- data.frame(
-#'     'variable'=rep(c('runif','rnorm'),each=100),
-#'     'value'=c(runif(100, min=-3, max=3), rnorm(100))
-#'   )
-#'   ggplot2::qplot(variable, value, data = distro, geom = 'quasirandom')
-#'   ggplot2::qplot(variable, value, data = distro) + geom_quasirandom(width=0.1)
+#'   ggplot2::qplot(class, hwy, data = ggplot2::mpg, position=position_quasirandom())
 #'
 position_quasirandom <- function (width = NULL, varwidth = FALSE, bandwidth=.5,nbins=NULL,method='quasirandom',groupOnX=NULL,dodge.width=0){
   ggplot2::ggproto(NULL,PositionQuasirandom,width = width, varwidth = varwidth, bandwidth=bandwidth,nbins=nbins,method=method,groupOnX=groupOnX,dodge.width=dodge.width)

--- a/man/geom_beeswarm.Rd
+++ b/man/geom_beeswarm.Rd
@@ -73,7 +73,7 @@ The beeswarm geom is a convenient means to offset points within categories to re
     'value'=c(runif(100, min=-3, max=3), rnorm(100))
   )
   ggplot2::qplot(variable, value, data = distro, geom='beeswarm')
-  ggplot2::qplot(variable, value, data = distro) +
+  ggplot2::ggplot(distro,aes(variable, value)) +
     geom_beeswarm(priority='density',cex=2.5)
 }
 \seealso{

--- a/man/geom_quasirandom.Rd
+++ b/man/geom_quasirandom.Rd
@@ -51,8 +51,8 @@ layer, as a string.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
@@ -83,7 +83,7 @@ The quasirandom geom is a convenient means to offset points within categories to
     'value'=c(runif(100, min=-3, max=3), rnorm(100))
   )
   ggplot2::qplot(variable, value, data = distro, geom = 'quasirandom')
-  ggplot2::qplot(variable, value, data = distro) + geom_quasirandom(width=0.1)
+  ggplot2::ggplot(distro,aes(variable, value)) + geom_quasirandom(width=0.1)
 }
 \seealso{
 \code{\link[vipor]{offsetX}} how spacing is determined,

--- a/man/ggbeeswarm.Rd
+++ b/man/ggbeeswarm.Rd
@@ -10,7 +10,7 @@ This package allows plotting of several groups of one dimensional data as a viol
 }
 \examples{
 
-  ggplot2::qplot(class, hwy, data = ggplot2::mpg, position=position_quasirandom())
+  ggplot2::ggplot(ggplot2::mpg,aes(class, hwy)) + geom_quasirandom()
   # Generate fake data
   distro <- data.frame(
     'variable'=rep(c('runif','rnorm'),each=100),

--- a/man/ggbeeswarm.Rd
+++ b/man/ggbeeswarm.Rd
@@ -16,8 +16,8 @@ This package allows plotting of several groups of one dimensional data as a viol
     'variable'=rep(c('runif','rnorm'),each=100),
     'value'=c(runif(100, min=-3, max=3), rnorm(100))
   )
-  ggplot2::qplot(variable, value, data = distro, position = position_quasirandom())
-  ggplot2::qplot(variable, value, data = distro, position = position_quasirandom(width=0.1))
+  ggplot2::ggplot(distro,aes(variable, value)) + geom_quasirandom()
+  ggplot2::ggplot(distro,aes(variable, value)) + geom_quasirandom(width=.1)
 
 }
 \author{

--- a/man/position_beeswarm.Rd
+++ b/man/position_beeswarm.Rd
@@ -21,15 +21,7 @@ Violin point-style plots to show overlapping points. x must be discrete.
 }
 \examples{
 
-  ggplot2::qplot(class, hwy, data = ggplot2::mpg, geom='beeswarm')
-  # Generate fake data
-  distro <- data.frame(
-    'variable'=rep(c('runif','rnorm'),each=100),
-    'value'=c(runif(100, min=-3, max=3), rnorm(100))
-  )
-  ggplot2::qplot(variable, value, data = distro, geom='beeswarm')
-  ggplot2::qplot(variable, value, data = distro) +
-    geom_beeswarm(priority='density',cex=2.5)
+  ggplot2::qplot(class, hwy, data = ggplot2::mpg, position=position_beeswarm())
 
 }
 \seealso{

--- a/man/position_quasirandom.Rd
+++ b/man/position_quasirandom.Rd
@@ -29,14 +29,7 @@ Violin point-style plots to show overlapping points. x must be discrete.
 }
 \examples{
 
-  ggplot2::qplot(class, hwy, data = ggplot2::mpg, geom='quasirandom')
-  # Generate fake data
-  distro <- data.frame(
-    'variable'=rep(c('runif','rnorm'),each=100),
-    'value'=c(runif(100, min=-3, max=3), rnorm(100))
-  )
-  ggplot2::qplot(variable, value, data = distro, geom = 'quasirandom')
-  ggplot2::qplot(variable, value, data = distro) + geom_quasirandom(width=0.1)
+  ggplot2::qplot(class, hwy, data = ggplot2::mpg, position=position_quasirandom())
 
 }
 \seealso{


### PR DESCRIPTION
# Remove qplot + geom_xxx() due to duplicated points (qplot plots then geom replots)
# Remove `position=` examples except in position_xxx functions (position= is deprecated and non-functional)
