### PR TITLE
fix typo in warning

### DIFF
--- a/R/position-beeswarm.R
+++ b/R/position-beeswarm.R
@@ -30,7 +30,7 @@ PositionBeeswarm <- ggplot2::ggproto("PositionBeeswarm",ggplot2:::Position, requ
 
     if(is.null(params$groupOnX)){
       params$groupOnX<-TRUE
-      if(length(unique(data$y)) <= length(unique(data$x))) warning('The default behavior of beeswarm has changed in version 0.6.0. In versions <0.6.0, this plot would have been dodged on the y-axis.  In versions >=0.6.0, grouponX=FALSE must be explicitly set to group on y-axis. Please set grouponX=TRUE/FALSE to avoid this warning and ensure proper axis choice.')
+      if(length(unique(data$y)) <= length(unique(data$x))) warning('The default behavior of beeswarm has changed in version 0.6.0. In versions <0.6.0, this plot would have been dodged on the y-axis.  In versions >=0.6.0, groupOnX=FALSE must be explicitly set to group on y-axis. Please set groupOnX=TRUE/FALSE to avoid this warning and ensure proper axis choice.')
     }
 
     # dodge


### PR DESCRIPTION
I forgot about this change, saw the warning, added `grouponX = FALSE`, kept seeing the warning, and then finally realized that the capitalization was wrong. Might be nice to keep this consistent.