### PR TITLE
Fix case where user passes in NA upper and/or lower bounds

### DIFF
--- a/R/position-beeswarm.R
+++ b/R/position-beeswarm.R
@@ -57,7 +57,7 @@ PositionBeeswarm <- ggplot2::ggproto("PositionBeeswarm",ggplot2:::Position, requ
 
     getScaleDiff<-function(scales){
       if(is.null(scales$limits))lims<-scales$range$range
-      else lims<-scales$limits
+      else lims<-scales$get_limits()
       if(inherits(scales,'ScaleContinuous')){
         limDiff<-diff(lims)
       }else if(inherits(scales,'ScaleDiscrete')){


### PR DESCRIPTION
When trying to set only one bound by passing in NA for the automatic limit you want to keep, ggbeeswarm currently throws an error:

```
data <- data.frame(x=factor(rep(1:2, each=50)), y=rnorm(100))
ggplot(data, aes(x, y)) +
  ggbeeswarm::geom_beeswarm() +
  ylim(c(NA, 2))
```

Using the method scales$get_limits() rather than accessing the limit values directly fixes this issue.