### PR TITLE
Fix `dodge.width` default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggbeeswarm
 Type: Package
 Title: Categorical Scatter (Violin Point) Plots
-Version: 0.7.1
+Version: 0.7.1.9000
 Date: 2022-12-05
 Authors@R: c(
     person(given="Erik", family="Clarke", role=c("aut", "cre"), email="erikclarke@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@ editor_options:
 
 # ggbeeswarm
 
+## Development version
+
+**Bugfixes:**
+
+- `position_quasirandom()` default `dodge.width` is now `NULL` instead of 0 (#79)
+- A few stray references to the deprecated `groupOnX` argument are removed.
+
 ## v0.7.1
 
 This release incorporates all the incredible work done by @csdaw to refactor the

--- a/R/geom-quasirandom.R
+++ b/R/geom-quasirandom.R
@@ -35,7 +35,7 @@ geom_quasirandom <- function(
   varwidth = FALSE,
   bandwidth = .5,
   nbins = NULL,
-  dodge.width = 0,
+  dodge.width = NULL,
   groupOnX = NULL,
   na.rm = FALSE,
   show.legend = NA,

--- a/R/position-quasirandom.R
+++ b/R/position-quasirandom.R
@@ -24,7 +24,7 @@ position_quasirandom <- function(
   varwidth = FALSE, 
   bandwidth = .5,
   nbins = NULL,
-  dodge.width = 0,
+  dodge.width = NULL,
   groupOnX = NULL,
   na.rm = FALSE
 ) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -63,7 +63,7 @@ Using `geom_quasirandom`:
 ggplot(mpg,aes(class, hwy)) + geom_quasirandom()
 
 # With categorical y-axis
-ggplot(mpg,aes(hwy, class)) + geom_quasirandom(groupOnX=FALSE)
+ggplot(mpg,aes(hwy, class)) + geom_quasirandom()
 
 # Some groups may have only a few points. Use `varwidth=TRUE` to adjust width dynamically.
 ggplot(mpg,aes(class, hwy)) + geom_quasirandom(varwidth = TRUE)

--- a/man/geom_quasirandom.Rd
+++ b/man/geom_quasirandom.Rd
@@ -14,7 +14,7 @@ geom_quasirandom(
   varwidth = FALSE,
   bandwidth = 0.5,
   nbins = NULL,
-  dodge.width = 0,
+  dodge.width = NULL,
   groupOnX = NULL,
   na.rm = FALSE,
   show.legend = NA,

--- a/man/position_quasirandom.Rd
+++ b/man/position_quasirandom.Rd
@@ -10,7 +10,7 @@ position_quasirandom(
   varwidth = FALSE,
   bandwidth = 0.5,
   nbins = NULL,
-  dodge.width = 0,
+  dodge.width = NULL,
   groupOnX = NULL,
   na.rm = FALSE
 )

--- a/vignettes/usageExamples.Rnw
+++ b/vignettes/usageExamples.Rnw
@@ -70,9 +70,9 @@ Factors can be used to generate custom group orderings:
 @
 \end{center}
 
-The axes can also be switched with a categorical y-axis using the argument \code{groupOnX=FALSE}:
+The axes can also be switched with a categorical y-axis:
 <<yaxis, echo=TRUE, eval=FALSE>>=
-  ggplot(mapping=aes(dat,labs)) + geom_quasirandom(aes(color=labs),groupOnX=FALSE)
+  ggplot(mapping=aes(dat,labs)) + geom_quasirandom(aes(color=labs))
 @
 \begin{center}
 <<showYaxis, fig=TRUE, height=3.5, width=5, echo=FALSE>>=
@@ -93,7 +93,7 @@ And dodging can be used to compare within groups:
 Or on the y-axis:
 <<dodgey, echo=TRUE, eval=FALSE>>=
   labs2<-factor(rep(1:2,each=n))
-  ggplot(mapping=aes(dat,labs,color=labs2)) + geom_quasirandom(dodge.width=.8,groupOnX=FALSE)
+  ggplot(mapping=aes(dat,labs,color=labs2)) + geom_quasirandom(dodge.width=.8)
 @
 \begin{center}
 <<showDodgey, fig=TRUE, height=3.5, width=5, echo=FALSE>>=


### PR DESCRIPTION
Hi Erik, apologies I haven't been able to help with this package as much as before (4th year PhD is busy surprisingly 😆 )

This small PR does the following:

- In quasirandom functions, change `dodge.width` default  to `NULL` instead of 0 (fixes #79)
- Removes a few stray references to deprecated `groupOnX` in the README and vignette
- Increments the package version from `0.7.1` to `0.7.1.9000`
- Updates NEWS.md with the above notes