### PR TITLE
Transform `xend` to support use in `geom_segment`

### DIFF
--- a/R/position-quasirandom.R
+++ b/R/position-quasirandom.R
@@ -196,6 +196,18 @@ offset_quasirandom <- function(
   
   x.offset <- x.offset * width
   data$x <- data$x + x.offset
+
+  if ('xend' %in% colnames(data) && 'yend' %in% colnames(data)) {
+      x.offset <- vipor::aveWithArgs(
+        data$yend, data$xend,
+        FUN = vipor::offsetSingleGroup,
+        maxLength = if (vary.width) {max.length} else {NULL},
+        ...
+      )
+
+      x.offset <- x.offset * width
+      data$xend <- data$xend + x.offset
+  }
   data
 }
 


### PR DESCRIPTION
This restores the ability to use `position_quasirandom` in  `geom_segment`, `geom_curve` and friends (see https://github.com/eclarke/ggbeeswarm/issues/55).

| Before | After |
|---|---|
|![image](https://github.com/eclarke/ggbeeswarm/assets/5832902/158dfd22-a3fb-4cef-9fc1-35277edc521f) | ![image](https://github.com/eclarke/ggbeeswarm/assets/5832902/9d176f94-65f7-42cb-9e81-7117fe726909) |


```R
library(ggplot2)
mpg$after2000 = mpg$year > 2000
data = aggregate(
    hwy ~ manufacturer + model + after2000 + drv,
    mpg,
    mean
)
(
    ggplot(data, aes(x=after2000, y=hwy))
    + geom_violin()
    + geom_segment(
       data=unstack(data, hwy ~ after2000),
       aes(x=FALSE, xend=TRUE, y=FALSE., yend=TRUE.),
       color='grey',
       position=ggbeeswarm::position_quasirandom()
    )
    + ggbeeswarm::geom_quasirandom(aes(color=drv))
    + scale_color_discrete(
        labels=c(
            'f'='front-wheel drive',
            'r'='rear-wheel drive',
            '4'='four-weel drive'
        ),
        name='the type of drive train'
    )
    + ylab('highway miles per gallon')
    + theme_bw()
)
```